### PR TITLE
fix(multica-web): keep API calls same-origin

### DIFF
--- a/apps/multica-web/entrypoint.sh
+++ b/apps/multica-web/entrypoint.sh
@@ -6,7 +6,6 @@ mkdir -p /config
 
 node - <<'EOF' > /config/runtime-config.js
 const config = {
-  apiBaseUrl: process.env.NEXT_PUBLIC_API_URL || "",
   googleClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
   wsUrl: process.env.NEXT_PUBLIC_WS_URL || "",
 };


### PR DESCRIPTION
## Summary\n- stop exposing runtime NEXT_PUBLIC_API_URL to the browser runtime config\n- keep browser API/auth requests same-origin so Next rewrites proxy to REMOTE_API_URL server-side\n\n## Verification\n- docker buildx bake image-local\n- ran multica-web:v0.3.10 with NEXT_PUBLIC_API_URL=http://backend:8080 and verified /runtime-config.js does not expose apiBaseUrl