### PR TITLE
fix(multica-web): apply backend URL at runtime

### DIFF
--- a/apps/multica-web/entrypoint.sh
+++ b/apps/multica-web/entrypoint.sh
@@ -4,6 +4,33 @@ set -eu
 
 mkdir -p /config
 
+node - <<'EOF'
+const fs = require("fs");
+
+const remoteApiUrl =
+  (process.env.REMOTE_API_URL || process.env.NEXT_PUBLIC_API_URL || "").trim();
+
+if (remoteApiUrl) {
+  const manifestPath = "/app/apps/web/.next/routes-manifest.json";
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const backendRoutes = new Map([
+    ["/api/:path*", "/api/:path*"],
+    ["/ws", "/ws"],
+    ["/auth/:path*", "/auth/:path*"],
+    ["/uploads/:path*", "/uploads/:path*"],
+  ]);
+
+  for (const rewrite of manifest.rewrites?.afterFiles || []) {
+    const destinationPath = backendRoutes.get(rewrite.source);
+    if (destinationPath) {
+      rewrite.destination = `${remoteApiUrl}${destinationPath}`;
+    }
+  }
+
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+EOF
+
 node - <<'EOF' > /config/runtime-config.js
 const config = {
   googleClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",


### PR DESCRIPTION
## Summary\n- rewrite Next's built routes manifest at container startup from REMOTE_API_URL\n- fall back to NEXT_PUBLIC_API_URL for existing deployments without exposing it to the browser\n- keeps /auth, /api, /ws, and /uploads same-origin in the browser while proxying server-side to the configured backend\n\n## Verification\n- docker buildx bake image-local\n- ran multica-web:v0.3.10 with REMOTE_API_URL=http://multica:8080 and verified routes-manifest rewrites point to http://multica:8080\n- verified /runtime-config.js does not expose apiBaseUrl or NEXT_PUBLIC_API_URL