### PR TITLE
release(multica): update multica-ai/multica to v0.3.11

### DIFF
--- a/apps/multica-web/docker-bake.hcl
+++ b/apps/multica-web/docker-bake.hcl
@@ -6,7 +6,7 @@ variable "APP" {
 
 variable "VERSION" {
   // renovate: datasource=github-releases depName=multica-ai/multica
-  default = "v0.3.10"
+  default = "v0.3.11"
 }
 
 variable "SOURCE" {

--- a/apps/multica/docker-bake.hcl
+++ b/apps/multica/docker-bake.hcl
@@ -6,7 +6,7 @@ variable "APP" {
 
 variable "VERSION" {
   // renovate: datasource=github-releases depName=multica-ai/multica
-  default = "v0.3.5"
+  default = "v0.3.11"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
## Summary
- Update multica image source version to v0.3.11
- Update multica-web image source version to v0.3.11

## Verification
- docker buildx bake --print for apps/multica
- docker buildx bake --print for apps/multica-web
- task local-build-multica
- task local-build-multica-web