### PR TITLE
fix(multica-web): allow larger proxied uploads

### DIFF
--- a/apps/multica-web/overrides/apps/web/next.config.ts
+++ b/apps/multica-web/overrides/apps/web/next.config.ts
@@ -30,6 +30,9 @@ const nextConfig: NextConfig = {
   ...(allowedDevOrigins && allowedDevOrigins.length > 0
     ? { allowedDevOrigins }
     : {}),
+  experimental: {
+    proxyClientMaxBodySize: "1gb",
+  },
   images: {
     formats: ["image/avif", "image/webp"],
     qualities: [75, 80, 85],


### PR DESCRIPTION
## Summary
- raise Next proxy client body size limit to 1gb for multica-web uploads

## Validation
- git diff --check