### PR TITLE
feat(postgresql): add CNPG PostgreSQL 18.4 image with pg_textsearch v1.3.0

### DIFF
--- a/apps/postgresql/Dockerfile
+++ b/apps/postgresql/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+ARG BASE_IMAGE=ghcr.io/cloudnative-pg/postgresql
+ARG POSTGRES_VERSION=18.4
+
+FROM docker.io/library/debian:trixie-slim AS pg-textsearch
+ARG TARGETARCH
+ARG PG_TEXTSEARCH_VERSION
+ARG PG_MAJOR=18
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN \
+    apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        curl \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN \
+    set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) sha256="4a8291b44c2c700ef71f9230e14fbe434dc0f8b20bca13eb31b049367911de38" ;; \
+        arm64) sha256="9590a2c604372d6ff05a8012ffd8f2a0caa74a8a6c81917ea5d12f3d0dad6ec6" ;; \
+        *) echo "unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    artifact="pg-textsearch-v${PG_TEXTSEARCH_VERSION}-pg${PG_MAJOR}-${TARGETARCH}.zip"; \
+    curl -fsSLo "/tmp/${artifact}" "https://github.com/timescale/pg_textsearch/releases/download/v${PG_TEXTSEARCH_VERSION}/${artifact}"; \
+    echo "${sha256}  /tmp/${artifact}" | sha256sum -c -; \
+    unzip -q "/tmp/${artifact}" -d /tmp/pg_textsearch; \
+    dpkg-deb -x /tmp/pg_textsearch/*.deb /tmp/rootfs
+
+FROM ${BASE_IMAGE}:${POSTGRES_VERSION}
+ARG PG_MAJOR=18
+
+USER root
+COPY --from=pg-textsearch /tmp/rootfs/usr/lib/postgresql/${PG_MAJOR}/lib/pg_textsearch.so /usr/lib/postgresql/${PG_MAJOR}/lib/pg_textsearch.so
+COPY --from=pg-textsearch /tmp/rootfs/usr/share/postgresql/${PG_MAJOR}/extension/pg_textsearch* /usr/share/postgresql/${PG_MAJOR}/extension/
+RUN \
+    chown root:root /usr/lib/postgresql/${PG_MAJOR}/lib/pg_textsearch.so /usr/share/postgresql/${PG_MAJOR}/extension/pg_textsearch* \
+    && chmod 755 /usr/lib/postgresql/${PG_MAJOR}/lib/pg_textsearch.so \
+    && chmod 644 /usr/share/postgresql/${PG_MAJOR}/extension/pg_textsearch*
+
+USER 26

--- a/apps/postgresql/docker-bake.hcl
+++ b/apps/postgresql/docker-bake.hcl
@@ -1,0 +1,57 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "postgresql"
+}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=loose
+  default = "18.4"
+}
+
+variable "POSTGRES_VERSION" {
+  default = VERSION
+}
+
+variable "POSTGRES_MAJOR" {
+  default = index(split(".", VERSION), 0)
+}
+
+variable "PG_TEXTSEARCH_VERSION" {
+  // renovate: datasource=github-releases depName=timescale/pg_textsearch
+  default = "1.3.0"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/cloudnative-pg/postgres-containers"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    POSTGRES_VERSION      = "${POSTGRES_VERSION}"
+    PG_MAJOR             = "${POSTGRES_MAJOR}"
+    PG_TEXTSEARCH_VERSION = "${PG_TEXTSEARCH_VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/postgresql/tests.yaml
+++ b/apps/postgresql/tests.yaml
@@ -1,0 +1,19 @@
+---
+schemaVersion: "2.0.0"
+commandTests:
+  - name: PostgreSQL version
+    command: pg_config
+    args:
+      - --version
+    expectedOutput:
+      - PostgreSQL 18.4
+fileExistenceTests:
+  - name: pg_textsearch library
+    path: /usr/lib/postgresql/18/lib/pg_textsearch.so
+    shouldExist: true
+  - name: pg_textsearch control file
+    path: /usr/share/postgresql/18/extension/pg_textsearch.control
+    shouldExist: true
+  - name: pg_textsearch SQL file
+    path: /usr/share/postgresql/18/extension/pg_textsearch--1.3.0.sql
+    shouldExist: true


### PR DESCRIPTION
CloudNativePG clusters need BM25-ranked full-text search via
pg_textsearch.  This image layers the Timescale extension onto
the official CNPG 18.4 base so that operators can set
shared_preload_libraries = pg_textsearch and CREATE EXTENSION.

Also fixes apps/caddy/Dockerfile where the second FROM stage
lacked ARG VERSION, causing the build to silently use an
unintended base tag.
